### PR TITLE
Revamp profile landing page layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,13 +1,5 @@
 title: Mantraraj Dash
-description: > 
-  Data Scientist with over 8 years of experience using ML/AI models on top of real world data to drive business value
-  <br><br>
-  Working currently as an Advanced Data Science Consultant at ZS Associates, based out of London, UK. 
-  <br><br>
-  <img align="left" width="40" src="https://raw.githubusercontent.com/mdash/mdash.github.io/dev/assets/img/contact.svg" alt="Contact">
-  <a href="https://linkedin.com/in/mantraraj">LinkedIn</a> 
-  <br>
-  <a href="mailto:mantraraj.dash@gmail.com">Email</a> 
+description: Senior Data Science and AI Leader specializing in agentic AI systems, GenAI, and ML solutions for complex real-world data.
 logo: /assets/img/profile_img.png
-show_downloads: False
+show_downloads: false
 theme: jekyll-theme-minimal

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,30 +13,9 @@
     {% include head-custom.html %}
   </head>
   <body>
-    <div class="wrapper">
-      <header>
-        <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-
-        {% if site.logo %}
-          <img src="{{site.logo | relative_url}}" alt="Logo" style="max-height: 125px; max-width: 125px;" />
-        {% endif %}
-
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
-
-        {% if site.show_downloads %}
-        <ul class="downloads">
-          <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
-          <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
-        </ul>
-        {% endif %}
-      </header>
-      <section>
-
+    <main class="page">
       {{ content }}
-
-      </section>
-    </div>
+    </main>
     <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
   </body>
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,254 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-alt: #f0f3f9;
+  --text: #0f172a;
+  --muted: #4b5563;
+  --border: #e5e7eb;
+  --primary: #1d4ed8;
+  --primary-dark: #1e40af;
+  --shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 64px 24px 80px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+  margin-bottom: 56px;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.6rem, 4vw, 3.6rem);
+  margin: 12px 0 16px;
+}
+
+.hero__content .lead {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: var(--muted);
+}
+
+.hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero__card {
+  background: var(--surface);
+  padding: 28px;
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.btn--primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.btn--primary:hover {
+  background: var(--primary-dark);
+}
+
+.btn--ghost {
+  border-color: var(--border);
+  color: var(--text);
+  background: #fff;
+}
+
+.section {
+  margin: 56px 0;
+}
+
+.section--alt {
+  background: var(--surface-alt);
+  padding: 40px;
+  border-radius: 24px;
+}
+
+.section__header {
+  margin-bottom: 24px;
+}
+
+.section__header p {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+}
+
+.grid--4 {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.grid--3 {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.grid--2 {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  padding: 24px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.05);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.timeline {
+  display: grid;
+  gap: 20px;
+}
+
+.timeline__item {
+  background: var(--surface);
+  padding: 20px 24px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+}
+
+.timeline__item span {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 16px 0;
+}
+
+.tag-row span {
+  background: var(--surface-alt);
+  color: var(--muted);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pill-list li {
+  background: var(--surface-alt);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.link {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.footer {
+  margin-top: 64px;
+  padding: 32px;
+  background: var(--surface);
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer__links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.footer__links a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .section--alt {
+    padding: 28px;
+  }
+
+  .footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -1,0 +1,240 @@
+---
+layout: default
+title: Mantraraj Dash
+---
+
+<section class="hero">
+  <div class="hero__content">
+    <p class="eyebrow">Senior Data Science &amp; AI Leader</p>
+    <h1>Mantraraj Dash</h1>
+    <p class="lead">
+      9+ years of experience leading data science, machine learning, and agentic AI initiatives
+      across regulated domains. Specialized in designing and scaling GenAI systems, RAG
+      applications, and end-to-end ML products with measurable business impact.
+    </p>
+    <div class="hero__actions">
+      <a class="btn btn--primary" href="mailto:mantraraj.dash@gmail.com">Contact</a>
+      <a class="btn btn--ghost" href="https://linkedin.com/in/mantraraj">LinkedIn</a>
+    </div>
+    <div class="hero__meta">
+      <span>London, UK</span>
+      <span>mantraraj.dash@gmail.com</span>
+    </div>
+  </div>
+  <div class="hero__card">
+    <h2>Professional Summary</h2>
+    <p>
+      Proven leader in building high-impact AI systems for digital customer experience, R&amp;D,
+      clinical data transformation, and enterprise knowledge discovery. Adept at translating
+      complex AI capabilities into strategic roadmaps and stakeholder-aligned outcomes.
+    </p>
+    <ul class="pill-list">
+      <li>Agentic AI Systems</li>
+      <li>GenAI &amp; RAG</li>
+      <li>MLOps Strategy</li>
+      <li>AI Program Leadership</li>
+    </ul>
+  </div>
+</section>
+
+<section class="section">
+  <div class="section__header">
+    <h2>Highlights</h2>
+    <p>Focused expertise across AI strategy, delivery, and team leadership.</p>
+  </div>
+  <div class="grid grid--4">
+    <div class="card">
+      <h3>9+ Years</h3>
+      <p>Hands-on experience in data science, ML, and AI program delivery.</p>
+    </div>
+    <div class="card">
+      <h3>AI Leadership</h3>
+      <p>Lead cross-functional teams from solution design to value realization.</p>
+    </div>
+    <div class="card">
+      <h3>GenAI Stack</h3>
+      <p>LangChain, LangGraph, Llama, GPT, Gemini, and production RAG systems.</p>
+    </div>
+    <div class="card">
+      <h3>Pharma &amp; R&amp;D</h3>
+      <p>Deep expertise in regulated environments and clinical workflows.</p>
+    </div>
+  </div>
+</section>
+
+<section class="section section--alt">
+  <div class="section__header">
+    <h2>Experience Snapshot</h2>
+    <p>ZS Associates, London &amp; India (2016–Present)</p>
+  </div>
+  <div class="timeline">
+    <div class="timeline__item">
+      <div>
+        <h3>Advanced Data Science Manager</h3>
+        <span>Jan 2025 – Present · London</span>
+      </div>
+      <p>
+        Lead AI practice initiatives across digital customer experience and R&amp;D; partner with
+        pharma clients to define vision, build agentic AI solutions, and deliver first-of-a-kind
+        programs.
+      </p>
+    </div>
+    <div class="timeline__item">
+      <div>
+        <h3>Advanced Data Science Consultant</h3>
+        <span>Apr 2022 – Dec 2024 · London</span>
+      </div>
+      <p>
+        Delivered ML and GenAI systems with robust MLOps, managed global delivery teams, and
+        supported AI business development across the EU and UK.
+      </p>
+    </div>
+    <div class="timeline__item">
+      <div>
+        <h3>Advanced Data Science Consultant</h3>
+        <span>2021 – Apr 2022 · India</span>
+      </div>
+      <p>Managed multi-client data science portfolios and delivered automation programs.</p>
+    </div>
+    <div class="timeline__item">
+      <div>
+        <h3>Advanced Data Science Associate Consultant</h3>
+        <span>2019 – 2020 · India</span>
+      </div>
+      <p>Led ML projects across RWE, NLP insights, and predictive analytics initiatives.</p>
+    </div>
+    <div class="timeline__item">
+      <div>
+        <h3>Data Analytics Associate</h3>
+        <span>2016 – 2018 · India</span>
+      </div>
+      <p>Delivered segmentation and sales force optimization solutions for pharma clients.</p>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="section__header">
+    <h2>Featured Projects</h2>
+    <p>Add or link to project case studies to demonstrate impact and expertise.</p>
+  </div>
+  <div class="grid grid--3">
+    <article class="card card--project">
+      <h3>Agentic Clinical Data Transformation</h3>
+      <p>
+        Automation workflow for data standardization and R code generation with 30–40% efficiency
+        gains.
+      </p>
+      <div class="tag-row">
+        <span>Agentic AI</span>
+        <span>Clinical Data</span>
+        <span>RAG</span>
+      </div>
+      <a class="link" href="#">Add project link →</a>
+    </article>
+    <article class="card card--project">
+      <h3>Enterprise Knowledge Chatbot</h3>
+      <p>
+        RAG + evaluation loops enabling 90% faithfulness for enterprise document discovery.
+      </p>
+      <div class="tag-row">
+        <span>GenAI</span>
+        <span>RAG</span>
+        <span>Search</span>
+      </div>
+      <a class="link" href="#">Add project link →</a>
+    </article>
+    <article class="card card--project">
+      <h3>AI Roadmap &amp; Portfolio Build</h3>
+      <p>
+        Strategic roadmap for AI-driven transformation of an international commercial division.
+      </p>
+      <div class="tag-row">
+        <span>Strategy</span>
+        <span>AI Transformation</span>
+        <span>Leadership</span>
+      </div>
+      <a class="link" href="#">Add project link →</a>
+    </article>
+  </div>
+</section>
+
+<section class="section section--alt">
+  <div class="section__header">
+    <h2>Latest Writing</h2>
+    <p>Placeholder slots for blog posts, articles, or conference talks.</p>
+  </div>
+  <div class="grid grid--3">
+    <article class="card card--post">
+      <h3>Designing Agentic AI Systems in Regulated Domains</h3>
+      <p class="muted">Blog · TBD</p>
+      <p>Short excerpt to summarize your point of view and insights.</p>
+      <a class="link" href="#">Add blog link →</a>
+    </article>
+    <article class="card card--post">
+      <h3>RAG Evaluation Loops: What Actually Works</h3>
+      <p class="muted">Article · TBD</p>
+      <p>Space to describe your approach and key takeaways.</p>
+      <a class="link" href="#">Add blog link →</a>
+    </article>
+    <article class="card card--post">
+      <h3>Scaling GenAI Programs Across Global Teams</h3>
+      <p class="muted">Talk · TBD</p>
+      <p>Highlight your leadership perspective and execution playbook.</p>
+      <a class="link" href="#">Add blog link →</a>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <div class="section__header">
+    <h2>Technical Expertise</h2>
+    <p>Core stack and focus areas.</p>
+  </div>
+  <div class="grid grid--3">
+    <div class="card">
+      <h3>Languages</h3>
+      <p>Python, PySpark, SQL</p>
+    </div>
+    <div class="card">
+      <h3>Frameworks</h3>
+      <p>Databricks, Spark, PyTorch, TensorFlow</p>
+    </div>
+    <div class="card">
+      <h3>GenAI</h3>
+      <p>Llama, GPT, Gemini, LangChain, LangGraph</p>
+    </div>
+  </div>
+</section>
+
+<section class="section section--alt">
+  <div class="section__header">
+    <h2>Education &amp; Certifications</h2>
+    <p>Academic background and credentials.</p>
+  </div>
+  <div class="grid grid--2">
+    <div class="card">
+      <h3>B.Tech in Engineering</h3>
+      <p>NIT Trichy, India</p>
+    </div>
+    <div class="card">
+      <h3>Certifications</h3>
+      <ul class="list">
+        <li>Data Science Nanodegree · Udacity</li>
+        <li>Machine Learning Specialization · Coursera (University of Washington)</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<footer class="footer">
+  <div>
+    <h2>Let’s build something impactful.</h2>
+    <p>Open to collaborations, speaking, and strategic AI engagements.</p>
+  </div>
+  <div class="footer__links">
+    <a href="mailto:mantraraj.dash@gmail.com">Email</a>
+    <a href="https://linkedin.com/in/mantraraj">LinkedIn</a>
+    <a href="#">Add GitHub</a>
+  </div>
+</footer>


### PR DESCRIPTION
### Motivation
- Refresh the personal site to present an updated, single-page profile that highlights leadership in GenAI and agentic AI systems. 
- Replace the default multi-element header with a simplified layout that lets custom landing content drive the page experience. 
- Add a tailored stylesheet to provide a modern, responsive visual design for resume highlights, projects, and blog placeholders.

### Description
- Simplified the base layout by replacing the previous header/wrapper with a focused `main` container in ` _layouts/default.html` to surface custom content.  
- Added a new landing page `index.md` containing hero, highlights, experience snapshot, featured projects, writing placeholders, technical expertise, and footer sections.  
- Introduced a custom stylesheet `assets/css/style.scss` with variables, responsive grid, and component styles for hero, cards, timeline, and footer.  
- Updated site metadata in ` _config.yml` to a concise professional description and normalized the `show_downloads` flag to `false`.

### Testing
- Attempted to verify build tooling by running `jekyll -v`, which failed with `command not found` so a local site build was not executed.  
- Performed repository inspections (`nl`/file listings) to confirm the new files `index.md` and `assets/css/style.scss` were created and that `_layouts/default.html` and `_config.yml` were modified.  
- No automated site-build tests or linters were run due to missing `jekyll` in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987d72cf4d083219acfb90bf02a2548)